### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: 'adopt-hotspot'
-          java-version: '8'
+          distribution: 'zulu'
+          java-version: '17'
       - run: ./gradlew build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 .idea
 build
+.intellijPlatform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # maven-artifacts-version-refactor Changelog
 
+## 1.0.6
+- Update dependencies.
+
 ## 1.0.5
 - Fix compatibility issue.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,11 @@
 ## Description
 
 <!-- Plugin description -->
-Helps to refactor a Maven <strong>pom.xml</strong> replacing inline dependencies/plugins versions with a dedicated property.
-
-This IntelliJ plugin adds an intention action that suggests extraction of a dependency/plugin version in a POM using a property.
-
-It adds an entry to **Preferences | Editor | Intentions | SDK Intentions**.
-
-It is a *high priority action*, enabled when the cursor is on a non-variable dependency/plugin xml node.
-
-Have a look at and contribute to the GitHub [repo](https://github.com/mirkoalicastro/maven-version-refactor-plugin).
+<p>Helps to refactor a Maven <strong>pom.xml</strong> replacing inline dependencies/plugins versions with a dedicated property.</p>
+<p>This IntelliJ plugin adds an intention action that suggests extraction of a dependency/plugin version in a POM using a property.</p>
+<p>It adds an entry to <strong>Preferences | Editor | Intentions | SDK Intentions</strong>.</p>
+<p>It is a <em>high priority action</em>, enabled when the cursor is on a non-variable dependency/plugin xml node.</p>
+<p>Have a look at and contribute to the GitHub <a href="https://github.com/mirkoalicastro/maven-version-refactor-plugin">repo</a>.</p>
 <!-- Plugin description end -->
 
 ## Installation

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,158 +1,124 @@
 import io.gitlab.arturbosch.detekt.Detekt
-import org.jetbrains.changelog.closure
-import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.changelog.Changelog
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    // Java support
     id("java")
-    // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.4.30"
-    // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "0.6.5"
-    // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-    id("org.jetbrains.changelog") version "1.1.1"
-    // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
-    id("io.gitlab.arturbosch.detekt") version "1.15.0"
-    // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
-    id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
-    // JaCoCo
-    id("jacoco")
+    id("org.jetbrains.kotlin.jvm") version "2.1.20"
+    id("org.jetbrains.intellij.platform") version "2.13.1"
+    id("org.jetbrains.changelog") version "2.2.1"
+    id("io.gitlab.arturbosch.detekt") version "1.23.7"
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
+    id("org.jetbrains.kotlinx.kover") version "0.9.1"
 }
 
-// Import variables from gradle.properties file
 val pluginGroup: String by project
-// `pluginName_` variable ends with `_` because of the collision with Kotlin magic getter in the `intellij` closure.
-// Read more about the issue: https://github.com/JetBrains/intellij-platform-plugin-template/issues/29
-val pluginName_: String by project
+val pluginName: String by project
 val pluginVersion: String by project
 val pluginSinceBuild: String by project
 val pluginUntilBuild: String by project
-val pluginVerifierIdeVersions: String by project
 
 val platformType: String by project
 val platformVersion: String by project
-val platformPlugins: String by project
-val platformDownloadSources: String by project
 
 group = pluginGroup
 version = pluginVersion
 
-// Configure project's dependencies
+kotlin {
+    jvmToolchain(21)
+}
+
 repositories {
     mavenCentral()
-    jcenter()
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
+
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.18.1")
-    testImplementation("io.kotest:kotest-runner-junit5:4.6.1")
-    testImplementation("io.mockk:mockk:1.12.0")
+    intellijPlatform {
+        create(platformType, platformVersion)
+        pluginVerifier()
+    }
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.7")
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+    testImplementation("io.mockk:mockk:1.13.12")
 }
 
-// Configure gradle-intellij-plugin plugin.
-// Read more: https://github.com/JetBrains/gradle-intellij-plugin
-intellij {
-    pluginName = pluginName_
-    version = platformVersion
-    type = platformType
-    downloadSources = platformDownloadSources.toBoolean()
-    updateSinceUntilBuild = true
-
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    setPlugins(*platformPlugins.split(',').map(String::trim).filter(String::isNotEmpty).toTypedArray())
-}
-
-// Configure detekt plugin.
-// Read more: https://detekt.github.io/detekt/kotlindsl.html
 detekt {
-    config = files("./detekt-config.yml")
+    config.setFrom("./detekt-config.yml")
     buildUponDefaultConfig = true
-
-    reports {
-        html.enabled = false
-        xml.enabled = false
-        txt.enabled = false
-    }
 }
 
-jacoco {
-    toolVersion = "0.8.6"
-}
-
-tasks {
-    // Set the compatibility versions to 1.8
-    withType<JavaCompile> {
-        sourceCompatibility = "1.8"
-        targetCompatibility = "1.8"
-    }
-    withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "1.8"
-    }
-
-    withType<Detekt> {
-        jvmTarget = "1.8"
-    }
-
-    test {
-        useJUnitPlatform()
-        finalizedBy(jacocoTestReport, jacocoTestCoverageVerification)
-        doLast {
-            println("View code coverage at: file://$buildDir/reports/jacoco/test/html/index.html")
+intellijPlatform {
+    pluginConfiguration {
+        name = pluginName
+        version = pluginVersion
+        description =
+            provider {
+                file("./README.md").readText().lines().run {
+                    val start = "<!-- Plugin description -->"
+                    val end = "<!-- Plugin description end -->"
+                    if (!containsAll(listOf(start, end))) {
+                        throw GradleException("Plugin description section not found in README.md")
+                    }
+                    subList(indexOf(start) + 1, indexOf(end))
+                }.joinToString("\n")
+            }
+        changeNotes =
+            provider {
+                changelog.renderItem(changelog.getLatest(), Changelog.OutputType.HTML)
+            }
+        ideaVersion {
+            sinceBuild = pluginSinceBuild
+            if (pluginUntilBuild.isNotEmpty()) {
+                untilBuild = pluginUntilBuild
+            }
         }
     }
-
-    jacocoTestReport {
-        dependsOn(test)
+    pluginVerification {
+        ides {
+            recommended()
+        }
     }
+    publishing {
+        token = providers.environmentVariable("PUBLISH_TOKEN")
+        channels = listOf(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first())
+    }
+}
 
-    jacocoTestCoverageVerification {
-        violationRules {
-            rule {
-                limit {
-                    minimum = BigDecimal.ONE
+kover {
+    reports {
+        total {
+            verify {
+                rule {
+                    bound {
+                        minValue = 100
+                    }
                 }
             }
         }
     }
+}
 
-    patchPluginXml {
-        version(pluginVersion)
-        sinceBuild(pluginSinceBuild)
-        untilBuild(pluginUntilBuild)
-
-        // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription(
-            closure {
-                file("./README.md").readText().lines().run {
-                    val start = "<!-- Plugin description -->"
-                    val end = "<!-- Plugin description end -->"
-
-                    if (!containsAll(listOf(start, end))) {
-                        throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
-                    }
-                    subList(indexOf(start) + 1, indexOf(end))
-                }.joinToString("\n").run { markdownToHTML(this) }
-            }
-        )
-
-        // Get the latest available change notes from the changelog file
-        changeNotes(
-            closure {
-                changelog.getLatest().toHTML()
-            }
-        )
+tasks {
+    withType<JavaCompile> {
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
-
-    runPluginVerifier {
-        ideVersions(pluginVerifierIdeVersions)
+    withType<KotlinCompile> {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
     }
-
+    withType<Detekt> {
+        jvmTarget = "17"
+    }
+    test {
+        useJUnitPlatform()
+    }
     publishPlugin {
         dependsOn("patchChangelog")
-        token(System.getenv("PUBLISH_TOKEN"))
-        // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
-        // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
-        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first())
     }
 }

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -1,9 +1,6 @@
 # Default detekt configuration:
 # https://github.com/detekt/detekt/blob/master/detekt-core/src/main/resources/default-detekt-config.yml
 
-formatting:
-  Indentation:
-    continuationIndentSize: 8
 naming:
   ConstructorParameterNaming:
     active: false

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,21 +2,12 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup = com.mirkoalicastro
-pluginName_ = Maven Version Refactor Plugin
-pluginVersion = 1.0.5
-pluginSinceBuild = 202
+pluginName = Maven Version Refactor Plugin
+pluginVersion = 1.0.6
+pluginSinceBuild = 223
 pluginUntilBuild =
-# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
-# See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.1.4, 2020.2.4, 2020.3.2, 2021.1, 2021.2
 
 platformType = IC
-platformVersion = 2020.2.4
-platformDownloadSources = true
-# Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-# Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins =
+platformVersion = 2024.1.7
 
-# Opt-out flag for bundling Kotlin standard library.
-# See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.
 kotlin.stdlib.default.dependency = true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,8 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = "Maven Version Refactor Plugin"

--- a/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/MavenVersionRefactorAction.kt
+++ b/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/MavenVersionRefactorAction.kt
@@ -10,17 +10,23 @@ import com.mirkoalicastro.mavenversionrefactor.factory.PomFactory
 import com.mirkoalicastro.mavenversionrefactor.provider.VersionNamingProvider
 
 class MavenVersionRefactorAction : PsiElementBaseIntentionAction(), IntentionAction, HighPriorityAction {
-
     private val pomFactory = PomFactory()
     private val versionNamingProvider = VersionNamingProvider()
 
-    override fun invoke(project: Project, editor: Editor?, psiElement: PsiElement) {
+    override fun invoke(
+        project: Project,
+        editor: Editor?,
+        psiElement: PsiElement,
+    ) {
         val pom = pomFactory.create(psiElement)
         pom?.let(versionNamingProvider::provide)?.let(pom::addVersion)
     }
 
-    override fun isAvailable(project: Project, editor: Editor?, psiElement: PsiElement) =
-        pomFactory.create(psiElement)?.let(versionNamingProvider::provide) != null
+    override fun isAvailable(
+        project: Project,
+        editor: Editor?,
+        psiElement: PsiElement,
+    ) = pomFactory.create(psiElement)?.let(versionNamingProvider::provide) != null
 
     override fun getText() = "Refactor version as property"
 

--- a/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/factory/PomFactory.kt
+++ b/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/factory/PomFactory.kt
@@ -21,7 +21,10 @@ class PomFactory {
             }
         }
 
-    private fun create(root: XmlTag, element: PsiElement): Pom? {
+    private fun create(
+        root: XmlTag,
+        element: PsiElement,
+    ): Pom? {
         val eligibleTag = findEligibleTag(element)
         val groupIdTag = eligibleTag?.getChildTag(Tag.GroupId.value)
         val artifactIdTag = eligibleTag?.getChildTag(Tag.ArtifactId.value)
@@ -47,8 +50,7 @@ class PomFactory {
             .find { it.name == Tag.Dependency.value || it.name == Tag.Plugin.value }
     }
 
-    private fun isVariable(str: String) =
-        str.matches(variablePattern)
+    private fun isVariable(str: String) = str.matches(variablePattern)
 
     private fun getPomRoot(element: PsiElement) =
         when {
@@ -56,6 +58,5 @@ class PomFactory {
             else -> null
         }
 
-    private fun isPomFile(element: PsiElement) =
-        element.containingFile.name.equals("pom.xml", ignoreCase = true)
+    private fun isPomFile(element: PsiElement) = element.containingFile.name.equals("pom.xml", ignoreCase = true)
 }

--- a/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/maven/Pom.kt
+++ b/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/maven/Pom.kt
@@ -5,7 +5,7 @@ import com.mirkoalicastro.mavenversionrefactor.xml.getChildTag
 
 data class Pom(
     val project: XmlTag,
-    val dependency: Dependency
+    val dependency: Dependency,
 ) {
     fun addVersion(name: String) {
         addProperty(getProperties(), name, dependency.version)
@@ -20,7 +20,11 @@ data class Pom(
 
     private fun getCurrentProperties() = project.getChildTag(Tag.Properties.value)
 
-    private fun addProperty(parent: XmlTag, name: String, value: String = "") {
+    private fun addProperty(
+        parent: XmlTag,
+        name: String,
+        value: String = "",
+    ) {
         val childTag = parent.createChildTag(name, parent.namespace, value, true)
         parent.addSubTag(childTag, true)
     }

--- a/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/maven/Tag.kt
+++ b/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/maven/Tag.kt
@@ -7,5 +7,5 @@ enum class Tag(val value: String) {
     Version("version"),
     GroupId("groupId"),
     ArtifactId("artifactId"),
-    Project("project")
+    Project("project"),
 }

--- a/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/provider/VersionNamingProvider.kt
+++ b/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/provider/VersionNamingProvider.kt
@@ -21,7 +21,11 @@ class VersionNamingProvider {
         }
     }
 
-    private tailrec fun fallback(properties: XmlTag?, dependency: Dependency, attempt: Int = 0): String? {
+    private tailrec fun fallback(
+        properties: XmlTag?,
+        dependency: Dependency,
+        attempt: Int = 0,
+    ): String? {
         val attemptSuffix = if (attempt > 0) "-$attempt" else ""
         val candidate = dependency.groupId + "-" + dependency.artifactId + attemptSuffix + VERSION_SUFFIX
 
@@ -32,6 +36,8 @@ class VersionNamingProvider {
         }
     }
 
-    private fun isPropertyAvailable(properties: XmlTag?, property: String) =
-        XMLChar.isValidName(property) && properties?.getChildTag(property) == null
+    private fun isPropertyAvailable(
+        properties: XmlTag?,
+        property: String,
+    ) = XMLChar.isValidName(property) && properties?.getChildTag(property) == null
 }

--- a/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/xml/Extensions.kt
+++ b/src/main/kotlin/com/mirkoalicastro/mavenversionrefactor/xml/Extensions.kt
@@ -1,10 +1,12 @@
 @file:JvmName("Extensions")
+
 package com.mirkoalicastro.mavenversionrefactor.xml
 
 import com.intellij.psi.xml.XmlTag
 
-fun XmlTag.getChildTag(name: String) = children
-    .filterIsInstance<XmlTag>()
-    .firstOrNull { name.equals(it.name, ignoreCase = true) }
+fun XmlTag.getChildTag(name: String) =
+    children
+        .filterIsInstance<XmlTag>()
+        .firstOrNull { name.equals(it.name, ignoreCase = true) }
 
 val XmlTag.textValue get() = value.textElements.getOrNull(0)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.mirkoalicastro.mavenversionrefactor</id>
     <name>Maven Version Refactor</name>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <vendor email="mirkoalicastro@gmail.com" url="http://www.mirkoalicastro.com">Mirko Alicastro</vendor>
 
     <!-- Product and plugin compatibility requirements -->

--- a/src/test/kotlin/com/mirkoalicastro/mavenversionrefactor/MavenVersionRefactorActionTest.kt
+++ b/src/test/kotlin/com/mirkoalicastro/mavenversionrefactor/MavenVersionRefactorActionTest.kt
@@ -78,7 +78,7 @@ class MavenVersionRefactorActionTest : StringSpec({
         table(
             headers("version", "available"),
             row(null, false),
-            row("dummyVersion", true)
+            row("dummyVersion", true),
         ).forAll { version, expected ->
             every { pomFactory.create(psiElement) } returns pom
             every { versionNamingProvider.provide(pom) } returns version
@@ -99,14 +99,18 @@ class MavenVersionRefactorActionTest : StringSpec({
     }
 })
 
-private fun createUnderTest(pomFactory: PomFactory, versionNamingProvider: VersionNamingProvider) =
-    MavenVersionRefactorAction().apply {
-        overrideField("pomFactory", pomFactory)
-        overrideField("versionNamingProvider", versionNamingProvider)
-    }
+private fun createUnderTest(
+    pomFactory: PomFactory,
+    versionNamingProvider: VersionNamingProvider,
+) = MavenVersionRefactorAction().apply {
+    overrideField("pomFactory", pomFactory)
+    overrideField("versionNamingProvider", versionNamingProvider)
+}
 
-private fun MavenVersionRefactorAction.overrideField(name: String, value: Any) =
-    MavenVersionRefactorAction::class.java.declaredFields
-        .firstOrNull { it.name == name }
-        ?.apply { isAccessible = true }
-        ?.set(this, value)
+private fun MavenVersionRefactorAction.overrideField(
+    name: String,
+    value: Any,
+) = MavenVersionRefactorAction::class.java.declaredFields
+    .firstOrNull { it.name == name }
+    ?.apply { isAccessible = true }
+    ?.set(this, value)

--- a/src/test/kotlin/com/mirkoalicastro/mavenversionrefactor/factory/PomFactoryTest.kt
+++ b/src/test/kotlin/com/mirkoalicastro/mavenversionrefactor/factory/PomFactoryTest.kt
@@ -43,9 +43,10 @@ class PomFactoryTest : StringSpec({
     }
 
     "should return null when file type is not XML" {
-        every { element.containingFile } returns mockk<JsonFile>().apply {
-            every { name } returns "pom.xml"
-        }
+        every { element.containingFile } returns
+            mockk<JsonFile>().apply {
+                every { name } returns "pom.xml"
+            }
 
         val actual = underTest.create(element)
 
@@ -101,7 +102,7 @@ class PomFactoryTest : StringSpec({
             headers("parents"),
             row(listOf(null, null, null)),
             row(listOf(element, null, null)),
-            row(listOf(element, element, null))
+            row(listOf(element, element, null)),
         ).forAll { parents ->
             every { element.containingFile } returns containingFile
             every { containingFile.name } returns "pom.xml"
@@ -151,7 +152,7 @@ class PomFactoryTest : StringSpec({
         table(
             headers("eligibleTagName", "actualVersion"),
             row("dependency", "\${version}"),
-            row("plugin", "\${test.version}")
+            row("plugin", "\${test.version}"),
         ).forAll { name, version ->
             every { element.containingFile } returns containingFile
             every { containingFile.name } returns "pom.xml"
@@ -176,7 +177,7 @@ class PomFactoryTest : StringSpec({
         table(
             headers("eligibleTagName"),
             row("dependency"),
-            row("plugin")
+            row("plugin"),
         ).forAll { name ->
             every { element.containingFile } returns containingFile
             every { containingFile.name } returns "pom.xml"
@@ -190,12 +191,14 @@ class PomFactoryTest : StringSpec({
             every { parent.getChildTag("version") } returns versionTag
             every { versionTag.textValue } returns versionText
             every { versionText.text } returns "123"
-            every { groupIdTag.value } returns mockk<XmlTagValue>().apply {
-                every { text } returns "groupId"
-            }
-            every { artifactIdTag.value } returns mockk<XmlTagValue>().apply {
-                every { text } returns "artifactId"
-            }
+            every { groupIdTag.value } returns
+                mockk<XmlTagValue>().apply {
+                    every { text } returns "groupId"
+                }
+            every { artifactIdTag.value } returns
+                mockk<XmlTagValue>().apply {
+                    every { text } returns "artifactId"
+                }
 
             val actual = underTest.create(element)
 

--- a/src/test/kotlin/com/mirkoalicastro/mavenversionrefactor/maven/PomTest.kt
+++ b/src/test/kotlin/com/mirkoalicastro/mavenversionrefactor/maven/PomTest.kt
@@ -32,14 +32,15 @@ class PomTest : StringSpec({
         justRun { dependency.version = "\${$name}" }
     }
 
-    fun verifyDirectFlow() = verify {
-        project.getChildTag("properties")
-        properties.namespace
-        dependency.version
-        properties.createChildTag(name, namespace, version, true)
-        properties.addSubTag(property, true)
-        dependency.version = "\${$name}"
-    }
+    fun verifyDirectFlow() =
+        verify {
+            project.getChildTag("properties")
+            properties.namespace
+            dependency.version
+            properties.createChildTag(name, namespace, version, true)
+            properties.addSubTag(property, true)
+            dependency.version = "\${$name}"
+        }
 
     beforeTest {
         mockkStatic("com.mirkoalicastro.mavenversionrefactor.xml.Extensions")

--- a/src/test/kotlin/com/mirkoalicastro/mavenversionrefactor/provider/VersionNamingProviderTest.kt
+++ b/src/test/kotlin/com/mirkoalicastro/mavenversionrefactor/provider/VersionNamingProviderTest.kt
@@ -71,7 +71,7 @@ class VersionNamingProviderTest : StringSpec({
             headers("times", "expected"),
             row(0, "$groupId-$artifactId-1.version"),
             row(1, "$groupId-$artifactId-2.version"),
-            row(2, "$groupId-$artifactId-3.version")
+            row(2, "$groupId-$artifactId-3.version"),
         ).forAll { times, expected ->
             every { pom.project } returns project
             every { project.getChildTag("properties") } returns properties

--- a/src/test/kotlin/com/mirkoalicastro/mavenversionrefactor/xml/ExtensionsKtTest.kt
+++ b/src/test/kotlin/com/mirkoalicastro/mavenversionrefactor/xml/ExtensionsKtTest.kt
@@ -46,7 +46,7 @@ class ExtensionsKtTest : StringSpec({
             headers("elements", "expected"),
             row(arrayOf<XmlText>(), null),
             row(arrayOf<XmlText>(firstElement), firstElement),
-            row(arrayOf<XmlText>(firstElement, mockk()), firstElement)
+            row(arrayOf<XmlText>(firstElement, mockk()), firstElement),
         ).forAll { elements, expected ->
             val underTest = createTextValueUnderTest(elements)
 


### PR DESCRIPTION
  Build system (major migration):
  - Gradle: 6.8.3 → 9.0
  - org.jetbrains.intellij 0.6.5 → org.jetbrains.intellij.platform 2.13.1
  - build.gradle.kts: full rewrite

  Language & dependencies:
  - Kotlin: 1.4.30 → 2.1.20
  - JVM target: 1.8 → 17 (with Java 21 toolchain for compilation)
  - JaCoCo → Kover 0.9.1 (JaCoCo incompatible with IntelliJ Platform Gradle Plugin 2.x test sandbox)

  Code changes:
  - ktlint auto-formatted all files
  - README.md: plugin description converted to HTML (replaces removed markdownToHTML())

  CI:
  - ci.yml: Java 8 → 17, actions/checkout@v2 → v4, actions/setup-java@v2 → v4, adopt-hotspot → zulu